### PR TITLE
Account for null values

### DIFF
--- a/src/Json/PrettyPrint.elm
+++ b/src/Json/PrettyPrint.elm
@@ -74,7 +74,7 @@ internalJsonToString json =
         JsonNull maybeInternalJson ->
             case maybeInternalJson of
                 Nothing ->
-                    "\"null\""
+                    "null"
 
                 Just json ->
                     internalJsonToString json

--- a/src/Json/PrettyPrint.elm
+++ b/src/Json/PrettyPrint.elm
@@ -1,7 +1,7 @@
 module Json.PrettyPrint exposing (..)
 
-import Json.Decode
 import Dict exposing (Dict)
+import Json.Decode
 
 
 type InternalJson
@@ -10,6 +10,7 @@ type InternalJson
     | JsonBool Bool
     | JsonObject (Dict String InternalJson)
     | JsonList (List InternalJson)
+    | JsonNull (Maybe InternalJson)
 
 
 decodeToInternalJson : Json.Decode.Decoder InternalJson
@@ -19,7 +20,8 @@ decodeToInternalJson =
         , Json.Decode.map JsonNumber Json.Decode.float
         , Json.Decode.map JsonBool Json.Decode.bool
         , Json.Decode.map JsonObject (Json.Decode.lazy (\_ -> Json.Decode.dict decodeToInternalJson))
-        , Json.Decode.map JsonList (Json.Decode.lazy (\_ -> (Json.Decode.list decodeToInternalJson)))
+        , Json.Decode.map JsonList (Json.Decode.lazy (\_ -> Json.Decode.list decodeToInternalJson))
+        , Json.Decode.map JsonNull (Json.Decode.lazy (\_ -> Json.Decode.nullable decodeToInternalJson))
         ]
 
 
@@ -68,3 +70,11 @@ internalJsonToString json =
             List.map internalJsonToString list
                 |> String.join ", "
                 |> (\x -> "[" ++ x ++ "]")
+
+        JsonNull maybeInternalJson ->
+            case maybeInternalJson of
+                Nothing ->
+                    "\"null\""
+
+                Just json ->
+                    internalJsonToString json


### PR DESCRIPTION
There was a bug when trying to pretty print a json with null values.

Json:
```json
{"a": 1, "b": "c", "d": {"e": 4}, "f": null}
```

Before:
```
I ran into the following problems: Expecting a String but instead got: {"a":1,"b":"c","d":{"e":4},"f":null} Expecting a Float but instead got: {"a":1,"b":"c","d":{"e":4},"f":null} Expecting a Bool but instead got: {"a":1,"b":"c","d":{"e":4},"f":null} I ran into the following problems at _.f: Expecting a String but instead got: null Expecting a Float but instead got: null Expecting a Bool but instead got: null Expecting an object but instead got: null Expecting a List but instead got: null Expecting a List but instead got: {"a":1,"b":"c","d":{"e":4},"f":null}
```

This PR handles null values

After:
![image](https://user-images.githubusercontent.com/6199588/41359297-ccf27758-6eef-11e8-9fe7-7af2336bb5a8.png)

